### PR TITLE
Pin nginx:alpine to nginx:1.29-alpine for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN bundle exec jekyll build
 
 # Stage 2: Serve with minimal nginx image
-FROM nginx:alpine
+FROM nginx:1.29-alpine
 
 COPY --from=builder /app/_site /usr/share/nginx/html
 


### PR DESCRIPTION
## Problem

The runtime stage of the `Dockerfile` uses an unpinned base image:

```dockerfile
FROM nginx:alpine
```

`nginx:alpine` resolves to whatever the latest nginx+Alpine combination is at build time. Two builds on different days can silently produce images with different nginx versions, which can introduce:

- Undetected behaviour changes between nginx minor versions
- Newly introduced CVEs (or miss a patch from a security release)

The builder stage (`ruby:4.0.2-alpine`) is already correctly pinned, making this inconsistency stand out.

This is the same issue fixed today in `melandnat.com` (#23), `resume` (#38), `subalpinedrift` (#11), and `reliableweb.dev` (#10).

## Fix

Pin the runtime base image from `nginx:alpine` to `nginx:1.29-alpine` (current stable at time of this PR).

```diff
-FROM nginx:alpine
+FROM nginx:1.29-alpine
```

## Testing

```bash
docker build -t pseudoweb .
docker run --rm -p 8080:8080 pseudoweb
curl http://localhost:8080/
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile runtime stage | `FROM nginx:alpine` unpinned | **Fixed (this PR)** |
| Dockerfile builder stage | `FROM ruby:4.0.2-alpine` — pinned ✓ | No action needed |
| `Gemfile.lock` | jekyll 4.4.1, all deps look current | No action needed |
| Jekyll static site | No dynamic content or user input | No action needed |
| **Future run** | `robot.villas` runtime stage runs as root (no `USER` instruction) | Worth a follow-up PR |
| **Future run** | `harvestarr` uses `pip install -U yt-dlp` without version pin | Worth a follow-up PR |
