### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM nginx:1.30-alpine
 
+LABEL org.opencontainers.image.source=https://github.com/icco/pseudoweb
+LABEL org.opencontainers.image.description="A git repository for my old blog"
+
 # Base image ships listen 80 in conf.d; remove so only 8080 is served.
 RUN rm -f /etc/nginx/conf.d/*.conf
 


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)