### PR TITLE
fix: emit nginx access logs as JSON

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,20 @@
+log_format json_combined escape=json
+'{'
+  '"time":"$time_iso8601",'
+  '"remote_addr":"$remote_addr",'
+  '"method":"$request_method",'
+  '"path":"$request_uri",'
+  '"status":$status,'
+  '"size":$body_bytes_sent,'
+  '"referer":"$http_referer",'
+  '"user_agent":"$http_user_agent",'
+  '"request_time":$request_time'
+'}';
+
 server {
     listen 8080 default_server;
     listen [::]:8080 default_server;
+    access_log /var/log/nginx/access.log json_combined;
     server_name localhost;
 
     include /etc/nginx/snippets/redirects.conf;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -14,7 +14,7 @@ log_format json_combined escape=json
 server {
     listen 8080 default_server;
     listen [::]:8080 default_server;
-    access_log /var/log/nginx/access.log json_combined;
+    access_log /dev/stdout json_combined;
     server_name localhost;
 
     include /etc/nginx/snippets/redirects.conf;


### PR DESCRIPTION
Switch nginx access log to JSON so Loki can parse method/path/status as fields.

## Test plan
- [ ] After deploy, `| json` parses the log line in Grafana.