### PR TITLE
ci: drop AGENTS.md reference from pr-title comment

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Allowed Conventional Commit types — keep in sync with AGENTS.md.
+          # Allowed Conventional Commit types
           types: |
             feat
             fix


### PR DESCRIPTION
Follow-up to #36: this repo has no AGENTS.md, so the reference is misleading.